### PR TITLE
using `context` over `content` for cloaked views

### DIFF
--- a/ember-cloaking.js
+++ b/ember-cloaking.js
@@ -202,7 +202,7 @@
         this.setProperties({
           style: null,
           loading: false,
-          containedView: this.createChildView(this.get('cloaks'), {content: this.get('content') })
+          containedView: this.createChildView(this.get('cloaks'), {context: this.get('content') })
         });
 
         this.rerender();


### PR DESCRIPTION
Thing is that `context` automatically goes as template context while `content` not. Actually I see the only way to use object from content in templates: bind `context` to `content`: `contextBinding: 'content'`.

BTW really interesting question is why `Ember.CollectionView` puts items to `content` for it's `childViews`
