### PR TITLE
Runs `scrolled` if content changes (i.e. async load)

### DIFF
--- a/demos/async.html
+++ b/demos/async.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/coffee-script/1.6.3/coffee-script.min.js"></script>
+  <script src="http:///cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0/handlebars.js"></script>
+  <script src="http://builds.emberjs.com/ember-latest.js"></script>
+  <script src="../ember-cloaking.js"></script>
+  <style>
+    .ember-view {
+      -webkit-animation: debug .3s;
+    }
+
+    @-webkit-keyframes debug {
+      0% {
+        background-color: yellow;
+      }
+      100% {
+        background-color: inherit;
+      }
+    }
+
+  </style>
+  <script type="text/coffeescript">
+    App = Ember.Application.create()
+    App.Router.map ->
+      @resource 'scroll'
+
+    # random nums for view height
+    random_height = ->
+      Math.round( Math.random()*100 + 20 )
+
+    # create a lots of crap
+    model =  ( { id: i, height: random_height() } for i in [0..500] )
+    App.ScrollRoute = Ember.Route.extend
+      model: ->
+        toReturn = []
+        Ember.run.later @, (->
+          toReturn.addObjects(model)
+        ), 100
+        toReturn
+
+    App.ScrollView = Em.View.extend
+      templateName: 'scroll'
+
+    App.ItemController = Em.ObjectController.extend
+      actions:
+        greeting: ->
+          alert('Hi! This is a message from ItemController.')
+
+    App.ItemView = Em.View.extend
+      templateName: 'item'
+
+      didInsertElement: ->
+        @$().css 'height', @get('context.height')
+
+  </script>
+  <title>Ember Cloaking Test</title>
+</head>
+<body>
+  <script type="text/x-handlebars">
+    {{#link-to "scroll"}}go to scroll{{/link-to}}
+    {{outlet}}
+  </script>
+
+  <script type="text/x-handlebars" data-template-name="scroll">
+    {{cloaked-collection cloakView="item" itemController="item" content=model}}
+  </script>
+    <script type="text/x-handlebars" data-template-name="item">
+      <div {{action greeting}}>
+        #{{id}} ({{height}}px)
+      </div>
+  </script>
+</body>
+</html>

--- a/ember-cloaking.js
+++ b/ember-cloaking.js
@@ -191,6 +191,7 @@
       $(window).bind('scroll.ember-cloak', onScrollMethod);
       this.addObserver('wrapperTop', self, onScrollMethod);
       this.addObserver('wrapperHeight', self, onScrollMethod);
+      this.addObserver('content.@each', self, onScrollMethod);
       this.scrollTriggered();
 
       this.set('scrollingEnabled', true);


### PR DESCRIPTION
Fixes issue following PR #15 being merged, specifically that the initial default-cloaking will result in content loaded asynchronously (i.e. after the view is inserted) also being cloaked, even if in view, until a scroll event is fired. This fix also fires `scrolled` if `content.@each` is updated.

In lieu of test cases, I've also added `demos/async.html` where this fix can be verified (I'm OK with removing this if not needed – the only difference from the main demo page is how the model is set).
