### PR TITLE
Recursively trigger willInsert/didInsertElement to behave like a #each.

### DIFF
--- a/ember-cloaking.js
+++ b/ember-cloaking.js
@@ -327,10 +327,11 @@
     render: function(buffer) {
       var containedView = this.get('containedView');
       if (containedView && containedView.get('state') !== 'inDOM') {
+        containedView.triggerRecursively('willInsertElement');
         containedView.renderToBuffer(buffer);
         containedView.transitionTo('inDOM');
         Em.run.schedule('afterRender', function() {
-          containedView.didInsertElement();
+          containedView.triggerRecursively('didInsertElement');
         });
       }
     }


### PR DESCRIPTION
This makes the `containedView`'s `childViews`  receive the `willInsertElement`/`didInsertElement` life cycle hooks.
