### PR TITLE
Bower version should match tag.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cloaking",
-  "version": "1.0.0-beta-3",
+  "version": "1.0.0-beta3",
   "main": "./ember-cloaking.js",
   "dependencies": {
     "ember": ">=1.3.0"


### PR DESCRIPTION
Got this warning during install:

```
bower mismatch      Version declared in the json (1.0.0-beta-3) is different than the resolved one (1.0.0-beta3)
```
