### PR TITLE
Correct visible view calculations when using a wrapper element

### DIFF
--- a/ember-cloaking.js
+++ b/ember-cloaking.js
@@ -86,13 +86,11 @@
     findTopView: function(childViews, viewportTop, min, max) {
       if (max < min) { return min; }
 
-      var wrapperTop = this.get('wrapperTop')>>0;
-
       while(max>min){
         var mid = Math.floor((min + max) / 2),
             // in case of not full-window scrolling
             $view = childViews[mid].$(),
-            viewBottom = $view.position().top + wrapperTop + $view.height();
+            viewBottom = $view.position().top + $view.height();
 
         if (viewBottom > viewportTop) {
           max = mid-1;

--- a/ember-cloaking.js
+++ b/ember-cloaking.js
@@ -150,8 +150,7 @@
         var view = childViews[bottomView],
           $view = view.$(),
           // in case of not full-window scrolling
-          scrollOffset = this.get('wrapperTop') || 0,
-          viewTop = $view.offset().top + scrollOffset,
+          viewTop = $view.position().top,
           viewBottom = viewTop + $view.height();
 
         if (viewTop > viewportBottom) { break; }


### PR DESCRIPTION
Both the find-top and find-bottom searches were incorrect (in different ways) for the case where you're scrolling the contents of one element (vs. the whole page). The details of the two problems are in the commit messages.

I believe that these changes will not affect the behavior in the full page scrolling case, but I have not tested that. (The change to find-top definitely will not affect full page scrolling — the value which is no longer added was always zero. The change to find-bottom effectively is substituting `position().top` for `offset().top`. I believe in the scrolling-the-whole-page case, these values are the same. In addition, the new find-bottom bounds computation now matches the find-top bounds computation, which further suggests to me that it's probably right.)