### PR TITLE
Height calculated using document rather than body

### DIFF
--- a/ember-cloaking.js
+++ b/ember-cloaking.js
@@ -129,7 +129,7 @@
           windowBottom = windowTop + windowHeight,
           viewportBottom = windowBottom + slack,
           topView = this.findTopView(childViews, viewportTop, 0, childViews.length-1),
-          bodyHeight = this.get('wrapperHeight') ? this.$().height() : $('body').height(),
+          bodyHeight = this.get('wrapperHeight') ? this.$().height() : $(document).height(),
           bottomView = topView,
           offsetFixedTopElement = this.get('offsetFixedTopElement'),
           offsetFixedBottomElement = this.get('offsetFixedBottomElement');


### PR DESCRIPTION
Pull request regarding issue https://github.com/eviltrout/ember-cloaking/issues/10.
Because of some CSS applied on the body tag, the body height doesn't come out to be correct. If instead same calculations are done with document height, the scrolled function works fine , as changed in the current pull request.